### PR TITLE
Front-end updates

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install
 
 # Bundle app source
 COPY . .
-COPY /config/.env.production .env
+COPY /src/config/.env.production .env
 
 RUN npm run build
 

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -35,6 +35,6 @@ app.use((req, res, next) => {
 app.use('/', inventoryRoutes);
 app.use('/orders', ordersRoutes);
 
-app.listen(7777, () => {
+app.listen(80, () => {
   console.log('server is running!');
 });


### PR DESCRIPTION
1. When I attempted to start the front-end with "npm run start" I recieved the following error:
- Error: error:0308010C:digital envelope routines::unsupported
I resolved this error by adding the following command to the npm start script located in package.json "--openssl-legacy-provider"
2. In App.js the Switch command was used for routing which is depreacted so I updated the Switch command to Routes
3. The file path for Inventory was incorrect in App.js so I updated the file path 