### PR TITLE
Erik frontend

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts  --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
-import Inventory from './src/pages/Inventory';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Inventory from './pages/Inventory';
 import Orders from './pages/Orders';
 import Settings from './pages/Settings';
 import './App.css';
@@ -34,15 +34,13 @@ function App() {
   return (
     <Router>
       <div className="App">
-        <header className="App-header">
-          Here we go
-        </header>
-        <Switch>
+        <header className="App-header">Here we go</header>
+        <Routes>
           <Route exact path="/" component={Inventory} />
           <Route path="/Orders" component={Orders} />
           <Route path="/Settings" component={Settings} />
           <Route path="/data" component={FetchData} />
-        </Switch>
+        </Routes>
       </div>
     </Router>
   );

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install
 
 # Bundle app source
 COPY . .
-COPY /config/.env.production .env
+COPY /src/config/.env.production .env
 
 RUN npm run build
 

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -35,6 +35,6 @@ app.use((req, res, next) => {
 app.use('/', inventoryRoutes);
 app.use('/orders', ordersRoutes);
 
-app.listen(80, () => {
+app.listen(7777, () => {
   console.log('server is running!');
 });

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -35,6 +35,6 @@ app.use((req, res, next) => {
 app.use('/', inventoryRoutes);
 app.use('/orders', ordersRoutes);
 
-app.listen(7777, () => {
+app.listen(80, () => {
   console.log('server is running!');
 });


### PR DESCRIPTION
1. When I attempted to start the front-end with "npm run start" I recieved the following error:
- Error: error:0308010C:digital envelope routines::unsupported
I resolved this error by adding the following command to the npm start script located in package.json "--openssl-legacy-provider"
2. In App.js the Switch command was used for routing which is depreacted so I updated the Switch command to Routes
3. The file path for Inventory was incorrect in App.js so I updated the file path 